### PR TITLE
Fix duplicate CSRF check

### DIFF
--- a/choochoowatch.py
+++ b/choochoowatch.py
@@ -46,8 +46,6 @@ def create_rentry_spoofed(content="🚦 ChooChoo Log"):
     csrf = token_tag["value"].strip() if token_tag and token_tag.has_attr("value") else ""
     if not csrf:
         raise Exception("Failed to retrieve CSRF token from Rentry")
-    if not csrf:
-        raise Exception("Failed to retrieve CSRF token from Rentry")
 
     data = {
         "csrf-token": csrf,


### PR DESCRIPTION
## Summary
- remove duplicated `if not csrf` block in `create_rentry_spoofed`

## Testing
- `python -m py_compile choochoowatch.py`

------
https://chatgpt.com/codex/tasks/task_e_687cec7fdde0832993a28aeb09509742