### PR TITLE
Fix newline replacement bug

### DIFF
--- a/choochoowatch.py
+++ b/choochoowatch.py
@@ -112,7 +112,7 @@ def fetch_trains():
         resp = requests.get(SIGNALBOX_API)
         log(f"Train data response code: {resp.status_code}")
         resp.raise_for_status()
-        content_snippet = resp.text[:300].replace('', ' ').replace('', '')
+        content_snippet = resp.text[:300].replace('\n', ' ')
         log(f"Response snippet: {content_snippet}...")
         data = resp.json()
         train_locs = data.get("train_locations", [])


### PR DESCRIPTION
## Summary
- ensure newline characters are replaced with spaces when logging snippets

## Testing
- `python -m py_compile choochoowatch.py`

------
https://chatgpt.com/codex/tasks/task_e_687ced101eb08329acb986578af47264