### PR TITLE
Remove extra error handler

### DIFF
--- a/choochoowatch.py
+++ b/choochoowatch.py
@@ -121,9 +121,6 @@ def fetch_trains():
     except Exception as e:
         log(f"Error fetching train data: {e}")
         return []
-    except Exception as e:
-        log(f"Error fetching train data: {e}")
-        return []
 
 def estimate_time_to_crossing(train, crossing_coord):
     loc = train.get("location", {})


### PR DESCRIPTION
## Summary
- remove a duplicate `except` block in `fetch_trains`

## Testing
- `python -m py_compile choochoowatch.py`

------
https://chatgpt.com/codex/tasks/task_e_687cee5682188329bd9256f7237a4ce9